### PR TITLE
修复假人的内存占用

### DIFF
--- a/src/main/java/dev/dubhe/curtain/features/player/patches/FakeClientConnection.java
+++ b/src/main/java/dev/dubhe/curtain/features/player/patches/FakeClientConnection.java
@@ -3,17 +3,27 @@ package dev.dubhe.curtain.features.player.patches;
 import dev.dubhe.curtain.features.player.fakes.IClientConnection;
 import io.netty.channel.embedded.EmbeddedChannel;
 import net.minecraft.network.Connection;
+import net.minecraft.network.PacketSendListener;
+import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
+
+import javax.annotation.Nullable;
 
 public class FakeClientConnection extends Connection {
     public FakeClientConnection(PacketFlow packetFlow) {
         super(packetFlow);
         ((IClientConnection) this).setChannel(new EmbeddedChannel());
+
     }
 
     @Override
     public void setReadOnly() {
     }
+
+    @Override
+    public void send(Packet<?> pPacket, @Nullable PacketSendListener pSendListener) {
+    }
+
 
     @Override
     public void handleDisconnection() {


### PR DESCRIPTION
在此变更前 (20G 内存分配吃了 16G)

![Before Patch](https://github.com/Gu-ZT/Curtain/assets/7685264/ce51f450-35e5-4914-8efb-d30ed243b230)

在此变更后 (运行了两个小时)

![After Patch](https://github.com/Gu-ZT/Curtain/assets/7685264/a6cf9148-07ce-4bea-b97c-57013d10fce4)

Close #147