### PR TITLE
修复 假人驻留 问题

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ forge_version=43.2.7
 # Mod Info
 maven_group=dev.dubhe
 archives_base_name=curtain
-version=1.3.3
+version=1.3.4
 build_number = undefined

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ forge_version=43.2.7
 # Mod Info
 maven_group=dev.dubhe
 archives_base_name=curtain
-version=1.3.2
+version=1.3.3
 build_number = undefined

--- a/src/main/java/dev/dubhe/curtain/CurtainRules.java
+++ b/src/main/java/dev/dubhe/curtain/CurtainRules.java
@@ -385,4 +385,9 @@ public class CurtainRules {
             categories = SURVIVAL
     )
     public static boolean betterSignEditing = false;
+
+    @Rule(
+            categories = {CREATIVE, SURVIVAL, FEATURE}
+    )
+    public static boolean toughWitherRose = false;
 }

--- a/src/main/java/dev/dubhe/curtain/events/rules/PlayerEventHandler.java
+++ b/src/main/java/dev/dubhe/curtain/events/rules/PlayerEventHandler.java
@@ -33,6 +33,8 @@ public class PlayerEventHandler {
 
     @SubscribeEvent
     public void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
+        // 如果新玩家加入时, 重置状态, 使假人退出能正常更新 HashMap
+        if (!(event.getEntity() instanceof EntityPlayerMPFake)) shouldExecute.set(true);
         FAKE_PLAYER_INVENTORY_MENU_MAP.put(event.getEntity(), new FakePlayerInventoryMenu(event.getEntity()));
     }
 

--- a/src/main/java/dev/dubhe/curtain/events/rules/PlayerEventHandler.java
+++ b/src/main/java/dev/dubhe/curtain/events/rules/PlayerEventHandler.java
@@ -13,10 +13,13 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static dev.dubhe.curtain.features.player.menu.MenuHashMap.FAKE_PLAYER_INVENTORY_MENU_MAP;
 
 public class PlayerEventHandler {
     // 假人背包(openFakePlayerInventory)
+    public static final AtomicBoolean shouldExecute = new AtomicBoolean(true);
     @SubscribeEvent
     public void onTick(TickEvent.PlayerTickEvent playerTickEvent) {
         if (CurtainRules.openFakePlayerInventory &&
@@ -35,8 +38,13 @@ public class PlayerEventHandler {
 
     @SubscribeEvent
     public void onPlayerLeave(PlayerEvent.PlayerLoggedOutEvent event) {
-        FAKE_PLAYER_INVENTORY_MENU_MAP.remove(event.getEntity());
+        if (!shouldExecute.get()) return;
+
+        if (event.getEntity() instanceof EntityPlayerMPFake) {
+            FAKE_PLAYER_INVENTORY_MENU_MAP.remove(event.getEntity());
+        } else shouldExecute.set(false);
     }
+
 
     // 工具缺失修复(missingTools)
     @SubscribeEvent

--- a/src/main/java/dev/dubhe/curtain/events/utils/ServerEventHandler.java
+++ b/src/main/java/dev/dubhe/curtain/events/utils/ServerEventHandler.java
@@ -1,6 +1,7 @@
 package dev.dubhe.curtain.events.utils;
 
 import dev.dubhe.curtain.CurtainRules;
+import dev.dubhe.curtain.events.rules.PlayerEventHandler;
 import dev.dubhe.curtain.features.logging.LoggerManager;
 import dev.dubhe.curtain.features.player.helpers.FakePlayerResident;
 import net.minecraft.server.level.ServerPlayer;
@@ -10,11 +11,16 @@ import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 public class ServerEventHandler {
+
     private int timer = 0;
+    public static final ReentrantLock lock = new ReentrantLock();
 
     @SubscribeEvent
     public void onServerStart(ServerStartedEvent event) {
+        PlayerEventHandler.shouldExecute.set(true);
         if (!event.getServer().isSingleplayer()) FakePlayerResident.onServerStart(event.getServer());
     }
 

--- a/src/main/java/dev/dubhe/curtain/features/player/helpers/FakePlayerResident.java
+++ b/src/main/java/dev/dubhe/curtain/features/player/helpers/FakePlayerResident.java
@@ -1,9 +1,11 @@
 package dev.dubhe.curtain.features.player.helpers;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.dubhe.curtain.CurtainRules;
+import dev.dubhe.curtain.events.rules.PlayerEventHandler;
 import dev.dubhe.curtain.features.player.patches.EntityPlayerMPFake;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -34,19 +36,20 @@ public class FakePlayerResident {
                 fakePlayerList.add(username, FakePlayerResident.save(player));
             });
             File file = server.getWorldPath(LevelResource.ROOT).resolve("fake_player.gca.json").toFile();
-            if (!file.isFile()) {
+            if (!file.exists()) {
                 try {
                     file.createNewFile();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
             }
             try (BufferedWriter bfw = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
-                bfw.write(new Gson().toJson(fakePlayerList));
+                bfw.write(new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(fakePlayerList));
             } catch (IOException e) {
                 e.printStackTrace();
             }
         }
+        PlayerEventHandler.shouldExecute.set(false);
         FAKE_PLAYER_INVENTORY_MENU_MAP.clear();
     }
 

--- a/src/main/java/dev/dubhe/curtain/mixins/rules/wither_rose_block/WitherRoseBlockMixin.java
+++ b/src/main/java/dev/dubhe/curtain/mixins/rules/wither_rose_block/WitherRoseBlockMixin.java
@@ -1,0 +1,20 @@
+package dev.dubhe.curtain.mixins.rules.wither_rose_block;
+
+import dev.dubhe.curtain.CurtainRules;
+import net.minecraft.world.level.block.WitherRoseBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(WitherRoseBlock.class)
+public abstract class WitherRoseBlockMixin {
+    @Inject(method = "mayPlaceOn", at = @At("HEAD"), cancellable = true)
+    private void toughWitherRouse(CallbackInfoReturnable<Boolean> cir)
+    {
+        if (CurtainRules.toughWitherRose)
+        {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/assets/curtain/lang/en_us.json
+++ b/src/main/resources/assets/curtain/lang/en_us.json
@@ -162,5 +162,8 @@
   "curtain.rules.anti_cheat_disabled.desc": "Prevents players from rubberbanding when moving too fast",
 
   "curtain.rules.better_sign_editing.name": "Better Sign Editing",
-  "curtain.rules.better_sign_editing.desc": "Possible to use feather editing sign with \"pen\" in the name"
+  "curtain.rules.better_sign_editing.desc": "Possible to use feather editing sign with \"pen\" in the name",
+
+  "curtain.rules.tough_wither_rose.name": "Resilient Rose",
+  "curtain.rules.tough_wither_rose.desc": "Place wither roses on any block"
 }

--- a/src/main/resources/assets/curtain/lang/zh_cn.json
+++ b/src/main/resources/assets/curtain/lang/zh_cn.json
@@ -162,5 +162,8 @@
   "curtain.rules.anti_cheat_disabled.desc": "防止玩家因为“本服务器未启用飞行”，“移动过快”等原因被踢出",
 
   "curtain.rules.better_sign_editing.name": "更好的告示牌编辑",
-  "curtain.rules.better_sign_editing.desc": "允许使用名称中包含“笔”的羽毛编辑告示牌"
+  "curtain.rules.better_sign_editing.desc": "允许使用名称中包含“笔”的羽毛编辑告示牌",
+
+  "curtain.rules.tough_wither_rose.name": "坚韧玫瑰",
+  "curtain.rules.tough_wither_rose.desc": "让凋零玫瑰在任意方块上放置"
 }

--- a/src/main/resources/curtain.mixins.json
+++ b/src/main/resources/curtain.mixins.json
@@ -53,7 +53,8 @@
     "rules.turtle_egg_trampled_disabled.TurtleEggBlockMixin",
     "rules.xp_from_explosions.ExplosionMixin",
     "rules.xp_no_cooldown.ExperienceOrbMixin",
-    "rules.xp_no_cooldown.PlayerMixin"
+    "rules.xp_no_cooldown.PlayerMixin",
+    "rules.wither_rose_block.WitherRoseBlockMixin"
   ],
   "client": [
     "rules.creative_no_clip.client.LevelRendererMixin"


### PR DESCRIPTION
修复 `假人驻留` 始终为 `{}` 问题
原因: 关闭存档时, 会使每个玩家均退出存档, 则会清空 `FAKE_PLAYER_INVENTORY_MENU_MAP` 随后再保存数据, 所以始终为 `{}`
修复: 关闭存档时, 始终是玩家为**第一个**退出存档, 当玩家退出后锁定 函数 `onPlayerLeave()` 则不会清空 `FAKE_PLAYER_INVENTORY_MENU_MAP`, **数据保存后**再解锁该函数, 或者**新玩家加入**村当时(兼容多人游戏), 或者**存档加载**时

Fix the issue of `fakePlayerResident` always being `{}`
Reason: When closing the save, it will cause each player to exit the save, which will clear the `FAKE-PLAYER-INVENTORY-MENU-MAP` and then save the data, so it will always be `{}`
Fix: When closing the save, the player is always **the first** to exit the save. If the player locks the function `onPlayerLeave()` after exiting, it will not clear the function `FAKE-PLAYER-INVENTORY-MENU-MAP`. After saving the data, the function will be unlocked again, or when a new player joins the server (for multiplayer games), or when the save is loaded